### PR TITLE
Update crosspost.py

### DIFF
--- a/cogs/crosspost.py
+++ b/cogs/crosspost.py
@@ -32,7 +32,7 @@ class CrosspostContext(BContext):
         file: File
         if file := kwargs.get("file"):  # type: ignore
             fp: BytesIO = file.fp  # type: ignore
-            if len(fp.getvalue()) >= 8_000_000:
+            if len(fp.getbuffer()) >= self.guild.filesize_limit:
                 args = ("Image too large to upload.",)
                 kwargs = {}
         msg = await super().send(*args, **kwargs)


### PR DESCRIPTION
The filesize limit is 8MiB, not 8MB. And it changes when the server is boosted.
We also use getbuffer() instead of getvalue(), as the latter copies the entire contents as a bytestring.